### PR TITLE
Ensure check for boxset flag is case insensitive

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -875,7 +875,9 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
                           strArtist.c_str(),
                           strAlbum.c_str());
     m_pDS->query(strSQL);
-    if (strType.find("boxset") != std::string::npos) //boxset flagged in album type
+    std::string strCheckFlag = strType;
+    StringUtils::ToLower(strCheckFlag);
+    if (strCheckFlag.find("boxset") != std::string::npos) //boxset flagged in album type
       bBoxedSet = true;
     if (m_pDS->num_rows() == 0)
     {


### PR DESCRIPTION
## Motivation and Context
In discussion on the forum here https://forum.kodi.tv/showthread.php?tid=349695&pid=2904992#pid2904992 users requested that the check be case insensitive as they wish to use a tag such as 'Boxset' rather than 'boxset'.

## How Has This Been Tested?
Runtime tested to build a fresh music library with an album tagged with 'BoxSet' in the album type.

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
