### PR TITLE
[music] make all discart available via Player.Art(album.discartN)

### DIFF
--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -298,6 +298,7 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
         int num = atoi(digits.c_str());
         if (num > 0 && startnum < artitem.artType.size())
         {
+          discartmap.insert(std::make_pair(artitem.mediaType + "." + artitem.artType, artitem.url));
           if (num == tag.GetDiscNumber())
             discartmap.insert(std::make_pair(artitem.artType.substr(0, startnum + 1), artitem.url));
           continue;


### PR DESCRIPTION
## Description
Allow skins to access all the discart(s) for an album via Player.Art(album.discartN) where N is a number between 1 and the number of discs the album contains.

## Motivation and Context
Requested by a team-member here https://forum.kodi.tv/showthread.php?tid=349695&pid=2902815#pid2902815 so that all disc art can be shown for a particular album in the same way the video library can show multiple disc artwork for collections.

## How Has This Been Tested?
Runtime tested by changing a variable to display the wrong disc image (eg Player.Art(album.discart2)) when playing a song from disc 1.

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
